### PR TITLE
(Fin.) Make 'stores/index/relationships.js' and define 'getters', 'setters'

### DIFF
--- a/app/assets/javascripts/src/stores/index/relationships.js
+++ b/app/assets/javascripts/src/stores/index/relationships.js
@@ -1,0 +1,59 @@
+
+// stores/index/relationships.js
+
+import Dispatcher from '../dispatcher'
+import BaseStore from '../base/store'
+import { ActionTypes } from '../utils'
+import _ from 'lodash'
+
+class RelationshipBaseStore extends BaseStore {
+
+  getRelationships() {
+
+    const initRelationships = [{ "2": {
+      id: 1, applicant_id: 2, recipient_id: 1,
+      timestamp_applicant: null, timestamp_recipient: null
+    } }]
+
+    // If 'key' is not associated yet, associating 'key' with 'init_obj'
+    // ** Without 'If', calling 'this.set(hoge, fuga)' endlessly
+    // ** http://www.sumimasen.com/tech/47146106.html
+    if (!this.get('relationships')) this.setRelationships(initRelationships)
+
+    // Returning an object associated with 'key'
+    return this.get('relationships')
+
+  }
+
+  setRelationships(relationships) {
+    this.set('relationships', relationships)
+  }
+
+  getOpenRelationship() {
+
+    const initOpenRelationship = {
+      id: 1, applicant_id: 2, recipient_id: 1,
+      timestamp_applicant: null, timestamp_recipient: null
+    }
+
+    if (!this.get('open_relationship')) this.setOpenRelationship(initOpenRelationship)
+    return this.get('open_relationship')
+
+  }
+
+  setOpenRelationship(openRelationship) {
+    this.set('open_relationship', openRelationship)
+  }
+
+  addChangeListener(callback) {
+    this.on('change', callback)
+  }
+
+  removeChangeListener(callback) {
+    this.off('change', callback)
+  }
+
+}
+
+// Creating a new instance 'RelationshipStore' from 'RelationshipBaseStore'
+const RelationshipStore = new RelationshipBaseStore()


### PR DESCRIPTION
・Relationship データベースに関連する store の作成
・getter, setter を定義（getProperties, setProperties の使用を停止）
（setRelationships は、api_v2/relationships#index 由来の json を set）
（setOpenRelationship は、api_v2/relationships#show 由来の json を set）