### PR TITLE
Modify #5, #20, #21, #22

### DIFF
--- a/app/controllers/api_v2/messages_controller.rb
+++ b/app/controllers/api_v2/messages_controller.rb
@@ -6,10 +6,20 @@ class ApiV2::MessagesController < ApplicationController
   # Totally renewed from 'api/messages#index'
   def index
 
-    # Will be passed from a client side
-    params[:user_id] = 7
+    # params[:self_id], params[:partner_ids] and params[:limit]
+    # being passed as query parameters
+    user = User.find(params[:self_id])
 
-    messages = @current_user.messages_with(params[:user_id])
+    # Setting 'id_params' defalut as 'user.friend_ids'
+    id_params = params[:partner_ids].blank? \
+      ? user.friend_ids : params[:partner_ids].map(&:to_i)
+
+    # Setting 'count_params' defalut as 'nil'
+    count_params = params[:limit].blank? \
+      ? nil : params[:limit].to_i
+
+    # Returning 'messages'
+    messages = user.messages(with_ids: id_params, top_newest_counts: count_params)
     render(json: messages)
 
   end

--- a/app/controllers/api_v2/messages_controller.rb
+++ b/app/controllers/api_v2/messages_controller.rb
@@ -14,9 +14,9 @@ class ApiV2::MessagesController < ApplicationController
     id_params = params[:partner_ids].blank? \
       ? user.friend_ids : params[:partner_ids].map(&:to_i)
 
-    # Setting 'count_params' defalut as 'nil'
+    # Setting 'count_params' defalut as '50'
     count_params = params[:limit].blank? \
-      ? nil : params[:limit].to_i
+      ? 50 : params[:limit].to_i
 
     # Returning 'messages'
     messages = user.messages(with_ids: id_params, top_newest_counts: count_params)
@@ -50,7 +50,7 @@ class ApiV2::MessagesController < ApplicationController
     timestamp = Time.zone.now.strftime('%s%3N')
 
     # Creating 'messages'
-    messages = Message.new(
+    new_message = Message.new(
       sent_from: @current_user.id,
       sent_to: params[:sent_to],
       contents: params[:contents],
@@ -73,11 +73,15 @@ class ApiV2::MessagesController < ApplicationController
 
     # ** 'save!' or update(strong_parameters) unnecessary
     # ** http://d.hatena.ne.jp/masterpiyo/20111212/1323677704
-    messages.save
+    if new_message.save
 
-    # ** If skipping 'render', rails will automatically
-    #    look for '.../create.html.haml'
-    render(json: '')
+      # ** If skipping 'render', rails will automatically
+      #    look for '.../create.html.haml'
+      render(json: '')
+
+    else
+      raise 'Failed to save a message'
+    end
 
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
     resources :friends,       only: :index
     resources :suggestions,   only: :index
     resources :messages,      only: %i[index create]
-    resources :relationships, only: %i[index create show update destroy]
+    resources :relationships, only: %i[index create update destroy]
   end
 
   # Creating routes for '/users' with 'devise'


### PR DESCRIPTION
・User モデルの messages, relationships メソッドで、対象とする friend_ids と
　一度に取得するメッセージ量を任意に設定できるように（処理量が多い場合はエラーを発生）
・messages と relationships の index を、クエリパラメータで参照
・messages と relationships の create に、保存失敗時の処理を追加