### PR TITLE
(Fin.) Modify stores

### DIFF
--- a/app/assets/javascripts/src/stores/index/messages.js
+++ b/app/assets/javascripts/src/stores/index/messages.js
@@ -1,42 +1,30 @@
 
-// stores/index/messages.js
+// Importing components
+import Dispatcher from '../../dispatcher'
+import BaseStore from '../../base/store'
+import { ActionTypes } from '../../utils'
+// import _ from 'lodash'
 
-import Dispatcher from '../dispatcher'
-import BaseStore from '../base/store'
-import { ActionTypes } from '../utils'
-import _ from 'lodash'
-
+// Defining getters and setters
 class MessageBaseStore extends BaseStore {
 
-  getMessages() {
-
-    const initMessages = [{ "0": [{
-      id: null, sent_from: null, sent_to: null, contents: '', timestamp: null
-    }] }]
-
+  getLastMessages() {
     // If 'key' is not associated yet, associating 'key' with 'init_obj'
     // ** Without 'If', calling 'this.set(hoge, fuga)' endlessly
     // ** http://www.sumimasen.com/tech/47146106.html
-    if (!this.get('messages')) this.setMessages(initMessages)
+    if (!this.get('last_messages')) this.setLastMessages([])
 
     // Returning an object associated with 'key'
-    return this.get('messages')
-
+    return this.get('last_messages')
   }
 
-  setMessages(messages) {
-    this.set('messages', messages)
+  setLastMessages(lastMessages) {
+    this.set('last_messages', lastMessages)
   }
 
   getOpenMessages() {
-
-    const initOpenMessages = [{
-      id: null, sent_from: null, sent_to: null, contents: '', timestamp: null
-    }]
-
-    if (!this.get('open_messages')) this.setOpenMessages(initOpenMessages)
+    if (!this.get('open_messages')) this.setOpenMessages([])
     return this.get('open_messages')
-
   }
 
   setOpenMessages(openMessages) {
@@ -55,3 +43,24 @@ class MessageBaseStore extends BaseStore {
 
 // Creating a new instance 'MessageStore' from 'MessageBaseStore'
 const MessageStore = new MessageBaseStore()
+
+// Defining a new 'dispatchToken' associated with 'MessageStore'
+MessageStore.dispatchToken = Dispatcher.register(payload => {
+  const action = payload.action
+
+  switch (action.type) {
+    case ActionTypes.GET_LAST_MESSAGES:
+      MessageStore.setLastMessages(action.json)
+      MessageStore.emitChange()
+      break
+
+    case ActionTypes.GET_OPEN_MESSAGES:
+      MessageStore.setOpenMessages(action.json)
+      MessageStore.emitChange()
+      break
+  }
+
+  return true
+})
+
+export default MessageStore

--- a/app/assets/javascripts/src/stores/index/relationships.js
+++ b/app/assets/javascripts/src/stores/index/relationships.js
@@ -1,28 +1,21 @@
 
-// stores/index/relationships.js
+// Importing components
+import Dispatcher from '../../dispatcher'
+import BaseStore from '../../base/store'
+import { ActionTypes } from '../../utils'
+// import _ from 'lodash'
 
-import Dispatcher from '../dispatcher'
-import BaseStore from '../base/store'
-import { ActionTypes } from '../utils'
-import _ from 'lodash'
-
+// Defining getters and setters
 class RelationshipBaseStore extends BaseStore {
 
   getRelationships() {
-
-    const initRelationships = [{ "0": {
-      id: null, applicant_id: null, recipient_id: null,
-      timestamp_applicant: null, timestamp_recipient: null
-    } }]
-
     // If 'key' is not associated yet, associating 'key' with 'init_obj'
     // ** Without 'If', calling 'this.set(hoge, fuga)' endlessly
     // ** http://www.sumimasen.com/tech/47146106.html
-    if (!this.get('relationships')) this.setRelationships(initRelationships)
+    if (!this.get('relationships')) this.setRelationships([])
 
     // Returning an object associated with 'key'
     return this.get('relationships')
-
   }
 
   setRelationships(relationships) {
@@ -30,15 +23,8 @@ class RelationshipBaseStore extends BaseStore {
   }
 
   getOpenRelationship() {
-
-    const initOpenRelationship = {
-      id: null, applicant_id: null, recipient_id: null,
-      timestamp_applicant: null, timestamp_recipient: null
-    }
-
-    if (!this.get('open_relationship')) this.setOpenRelationship(initOpenRelationship)
+    if (!this.get('open_relationship')) this.setOpenRelationship([])
     return this.get('open_relationship')
-
   }
 
   setOpenRelationship(openRelationship) {
@@ -57,3 +43,19 @@ class RelationshipBaseStore extends BaseStore {
 
 // Creating a new instance 'RelationshipStore' from 'RelationshipBaseStore'
 const RelationshipStore = new RelationshipBaseStore()
+
+// Defining a new 'dispatchToken' associated with 'RelationshipStore'
+RelationshipStore.dispatchToken = Dispatcher.register(payload => {
+  const action = payload.action
+
+  switch (action.type) {
+    case ActionTypes.GET_RELATIONSHIPS:
+      RelationshipStore.setRelationships(action.json)
+      RelationshipStore.emitChange()
+      break
+  }
+
+  return true
+})
+
+export default RelationshipStore

--- a/app/assets/javascripts/src/stores/index/users.js
+++ b/app/assets/javascripts/src/stores/index/users.js
@@ -1,28 +1,21 @@
 
-// stores/index/users.js
+// Importing components
+import Dispatcher from '../../dispatcher'
+import BaseStore from '../../base/store'
+import { ActionTypes } from '../../utils'
+// import _ from 'lodash'
 
-import Dispatcher from '../dispatcher'
-import BaseStore from '../base/store'
-import { ActionTypes } from '../utils'
-import _ from 'lodash'
-
+// Defining getters and setters
 class UserBaseStore extends BaseStore {
 
   getFriends() {
-
-    const initFriends = [{
-      id: null, name: '', profile_picture: '', profile_comment: '',
-      status: null, read: null, email: ''
-    }]
-
     // If 'key' is not associated yet, associating 'key' with 'init_obj'
     // ** Without 'If', calling 'this.set(hoge, fuga)' endlessly
     // ** http://www.sumimasen.com/tech/47146106.html
-    if (!this.get('friends')) this.setFriends(initFriends)
+    if (!this.get('friends')) this.setFriends([])
 
     // Returning an object associated with 'key'
     return this.get('friends')
-
   }
 
   setFriends(friends) {
@@ -30,15 +23,8 @@ class UserBaseStore extends BaseStore {
   }
 
   getSuggestions() {
-
-    const initSuggestions = [{
-      id: null, name: '', profile_picture: '', profile_comment: '',
-      status: null, read: null, email: ''
-    }]
-
-    if (!this.get('suggestions')) this.setSuggestions(initSuggestions)
+    if (!this.get('suggestions')) this.setSuggestions([])
     return this.get('suggestions')
-
   }
 
   setSuggestions(suggestions) {
@@ -46,7 +32,7 @@ class UserBaseStore extends BaseStore {
   }
 
   getOpenUserTab() {
-    if (!this.get('open_user_tab')) this.setOpenUserTab("Friends")
+    if (!this.get('open_user_tab')) this.setOpenUserTab('Friends')
     return this.get('open_user_tab')
   }
 
@@ -55,7 +41,7 @@ class UserBaseStore extends BaseStore {
   }
 
   getOpenContent() {
-    if (!this.get('open_content')) this.setOpenContent("Messages")
+    if (!this.get('open_content')) this.setOpenContent('Messages')
     return this.get('open_content')
   }
 
@@ -93,3 +79,39 @@ class UserBaseStore extends BaseStore {
 
 // Creating a new instance 'UserStore' from 'UserBaseStore'
 const UserStore = new UserBaseStore()
+
+// Defining a new 'dispatchToken' associated with 'UserStore'
+UserStore.dispatchToken = Dispatcher.register(payload => {
+  const action = payload.action
+
+  switch (action.type) {
+    case ActionTypes.GET_CURRENT_USER_ID:
+      UserStore.setCurrentUserID(action.json.id)
+      UserStore.emitChange()
+      break
+
+    case ActionTypes.GET_FRIENDS:
+      UserStore.setFriends(action.json)
+      UserStore.emitChange()
+      break
+
+    case ActionTypes.GET_SUGGESTIONS:
+      UserStore.setSuggestions(action.json)
+      UserStore.emitChange()
+      break
+
+    case ActionTypes.CHANGE_OPEN_USER_ID:
+      UserStore.setOpenUserID(action.userID)
+      UserStore.emitChange()
+      break
+
+    case ActionTypes.CHANGE_OPEN_USER_TAB:
+      UserStore.setOpenUserTab(action.userTab)
+      UserStore.emitChange()
+      break
+  }
+
+  return true
+})
+
+export default UserStore

--- a/app/controllers/api_v2/relationships_controller.rb
+++ b/app/controllers/api_v2/relationships_controller.rb
@@ -5,6 +5,8 @@
 #                 destroying a relationship                   (destroy)
 class ApiV2::RelationshipsController < ApplicationController
 
+  protect_from_forgery except: :update
+
   # Newly created
   def index
 
@@ -66,16 +68,21 @@ class ApiV2::RelationshipsController < ApplicationController
   # Extracted from 'api/messages#create'
   def update
 
+    timestamp = Time.zone.now.strftime('%s%3N')
+
     # Finding 'user' on scope
-    user = User.find(params[:partner_id])
+    user = User.find(params[:self_id])
 
     # Finding relationships concerning 'user'
-    user_active = user.active_relationship.find_by(recipient_id: params[:self_id])
-    user_passive = user.passive_relationship.find_by(applicant_id: params[:self_id])
+    user_active = user.active_relationship.find_by(recipient_id: params[:partner_id])
+    user_passive = user.passive_relationship.find_by(applicant_id: params[:partner_id])
 
     # Updating 'timestamp'
-    user_active.update!(timestamp_recipient: params[:timestamp])
-    user_passive.update!(timestamp_applicant: params[:timestamp])
+    if user_active
+      user_active.update!(timestamp_applicant: timestamp)
+    elsif user_passive
+      user_passive.update!(timestamp_recipient: timestamp)
+    end
 
     render(json: '')
 


### PR DESCRIPTION
・getter の初期値を [] や null に変更（キーが変わった！と怒られなくなりました）
・relationship#update が機能するように変更（protect_from_forgery を無効に）
（保存の際、場合分けしないと「値が無いぞ！」と怒られたので、場合分けを復活）