### PR TITLE
(Fin.) Modify components from #33

### DIFF
--- a/app/assets/javascripts/src/components/index/app.js
+++ b/app/assets/javascripts/src/components/index/app.js
@@ -11,11 +11,11 @@ import RelationshipStore from '../../stores/index/relationships'
 import UsersTab from './usersTab'
 import FriendsList from './friendsList'
 import SuggestionsList from './suggestionsList'
-// import SearchBox from './4_searchBox'
-// import UserShortProf from './5_userShortProf'
-// import UserProf from './6_userProf'
-// import MessagesList from './7_messagesList'
-// import ReplyBox from './8_replyBox'
+import SearchBox from './searchBox'
+import UserShortProf from './userShortProf'
+import UserProf from './userProf'
+import MessagesList from './messagesList'
+import ReplyBox from './replyBox'
 
 // Creating a new class 'App'
 class App extends React.Component {
@@ -48,6 +48,7 @@ class App extends React.Component {
       openUserID: UserStore.getOpenUserID(),
       friends: UserStore.getFriends(),
       suggestions: UserStore.getSuggestions(),
+      searchText: UserStore.getSearchText(),
       openMessages: MessageStore.getOpenMessages(),
       lastMessages: MessageStore.getLastMessages(),
       relationships: RelationshipStore.getRelationships(),
@@ -76,7 +77,6 @@ class App extends React.Component {
   // Passing the parent class' 'state' to the child class 'props'
   // ** https://qiita.com/KeitaMoromizato/items/0da6c8e4264b1f206451
   render() {
-    console.log(this.state)
 
     // Defining an object for facilitation
     // ** https://qiita.com/uto-usui/items/a9d17447fe81c17c41fa
@@ -88,13 +88,13 @@ class App extends React.Component {
           <div className='app'>
             <div className='users-box'>
               <UsersTab { ...this.state }/>
-              {/*<SearchBox openUserTab={openUserTab} />*/}
+              <SearchBox { ...this.state }/>
               <SuggestionsList { ...this.state }/>
             </div>
-            {/*<div className='messages-box'>
+            <div className='messages-box'>
               <UserShortProf { ...this.state }/>
               <UserProf { ...this.state }/>
-            </div>*/}
+            </div>
           </div>
       )
 
@@ -104,29 +104,29 @@ class App extends React.Component {
           <div className='app'>
             <div className='users-box'>
               <UsersTab { ...this.state }/>
-              {/*<SearchBox openUserTab={openUserTab} />*/}
+              <SearchBox { ...this.state }/>
               <FriendsList { ...this.state }/>
             </div>
-            {/*<div className='messages-box'>
+            <div className='messages-box'>
               <UserShortProf { ...this.state }/>
               <UserProf { ...this.state }/>
-            </div>*/}
+            </div>
           </div>
       )
 
     // Else if 'openUserID' is defined as 'none', rendering 'FriendsList' and 'MessagesList'
-    } else if (_.isString(openUserID)) {
+    } else if (!openUserID) {
       return (
           <div className='app'>
             <div className='users-box'>
               <UsersTab { ...this.state }/>
-              {/*<SearchBox openUserTab={openUserTab} />*/}
+              <SearchBox { ...this.state }/>
               <FriendsList { ...this.state }/>
             </div>
-            {/*<div className='messages-box'>
+            <div className='messages-box'>
               <UserShortProf { ...this.state }/>
               <MessagesList { ...this.state }/>
-            </div>*/}
+            </div>
           </div>
       )
 
@@ -136,14 +136,14 @@ class App extends React.Component {
           <div className='app'>
             <div className='users-box'>
               <UsersTab { ...this.state }/>
-              {/*<SearchBox openUserTab={openUserTab}/>*/}
+              <SearchBox { ...this.state }/>
               <FriendsList { ...this.state }/>
             </div>
-            {/*<div className='messages-box'>
+            <div className='messages-box'>
               <UserShortProf { ...this.state }/>
               <MessagesList { ...this.state }/>
               <ReplyBox { ...this.state }/>
-            </div>*/}
+            </div>
           </div>
       )
 

--- a/app/assets/javascripts/src/components/index/suggestionsList.js
+++ b/app/assets/javascripts/src/components/index/suggestionsList.js
@@ -13,11 +13,20 @@ class SuggestionsList extends React.Component {
   }
 
   render() {
-    const { openUserID, suggestions } = this.props
+    const { currentUserID, openUserID, suggestions } = this.props
 
-    // When 'this.props' is imperfect, displaying 'No suggestions'
-    // TODO: concatenate 'if' condition if possible
-    if (!suggestions.length) {
+    // When 'this.props' is imperfect (during initial render), or
+    // when 'current_user' has no suggestions, displaying 'No friends'
+    const skipRenderFirst = !currentUserID || !suggestions.length
+
+    // When 'openUserID' does exist but does not match 'friends' list
+    // (during rerender), displaying 'No friends'
+    // ** When 'openUserID' is null, should not skip Rendering
+    // ** Initialization of 'openUserID' needed afterwards
+    const skipRenderAfterUpdate
+      = openUserID && !(_.find(suggestions, { 'id': openUserID }))
+
+    if (skipRenderFirst || skipRenderAfterUpdate) {
       return (
           <div className='suggestions-list__list suggestions-list__list__empty'>
             No suggestions
@@ -38,6 +47,14 @@ class SuggestionsList extends React.Component {
       if (a.user.name > b.user.name) return 1;
       return 0;
     })
+
+    // Initializing 'openUserID'
+    // Delayed intentionally because dispatch from 'app.js' not completed yet
+    // ** ('dispatch' mechanism) https://github.com/rafrex/flux-async-dispatcher
+    if (!openUserID) {
+      const initOpenUserID = suggestionsSorted[0].user.id
+      setTimeout(() => this.changeOpenUserID(initOpenUserID), 1)
+    }
 
     // Rendering 'friendsSorted'
     const suggestionsList = suggestionsSorted.map((suggestion, index) => {

--- a/app/assets/javascripts/src/components/index/usersTab.js
+++ b/app/assets/javascripts/src/components/index/usersTab.js
@@ -3,12 +3,27 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import UserAction from '../../actions/index/users'
+import UserStore from '../../stores/index/users'
 
 class UsersTab extends React.Component {
 
-  // When a tab (friends or suggestions) is clicked, updating 'openUserTab'
-  async changeOpenUserTab(openUserTab) {
-    await UserAction.changeOpenUserTab(openUserTab)
+  // When a tab (friends or suggestions) is clicked
+  changeOpenUserTab(openUserTab) {
+    // Updating 'openUserTab'
+    UserAction.changeOpenUserTab(openUserTab)
+
+    // Initializing 'userSearchText' (because a set of users changes)
+    UserAction.updateSearchText(null)
+
+    // Initializing 'openUserID' (because a set of users changes)
+    UserAction.changeOpenUserID(null)
+
+    // Initializing 'friends' or 'suggestions' list
+    // (Because these list might be changed after search)
+    const currentUserID = UserStore.getCurrentUserID()
+    openUserTab === 'Friends'
+      ? UserAction.getFriends(currentUserID)
+      : UserAction.getSuggestions(currentUserID)
   }
 
   render() {


### PR DESCRIPTION
・this.state に searchText を追加（searchText の初期化を usersTab から発火するため）
・friendsList, suggestionsList では、複数の props の更新途中で render してエラーを吐いていた
-> skipRenderFirst と skipRenderAfterUpdate を定義し、false の場合は render しないよう設定
・friendsList, suggestionsList では、最初に render した時に openUserID = null となっていた
-> 全ての dispatch が終わった後に openUserID を設定
・usersTab では、タブを切り替えた時に複数の初期化アクションを発火