### PR TITLE
Incorporate 'partner_id' into each 'relationships' object, and modify components

### DIFF
--- a/app/assets/javascripts/src/components/index/friendsList.js
+++ b/app/assets/javascripts/src/components/index/friendsList.js
@@ -52,10 +52,9 @@ class FriendsList extends React.Component {
 
     const friendsInfo = friends.map((friend, index) => {
       let friendInfo = []
-      const friendID = String(friend.id)
-      const relationship = _.find(relationships, friendID)[friendID]
       friendInfo.user = friend
-      friendInfo.message = _.find(lastMessages, friendID)[friendID][0]
+      friendInfo.message = _.find(lastMessages, { partnerId: friend.id })
+      const relationship = _.find(relationships, { partnerId: friend.id })
       friendInfo.timestamp = (relationship.applicantId === currentUserID)
         ? { currentUser: relationship.timestampApplicant,
             friend: relationship.timestampRecipient }

--- a/app/assets/javascripts/src/components/index/messagesList.js
+++ b/app/assets/javascripts/src/components/index/messagesList.js
@@ -13,8 +13,8 @@ class MessagesList extends React.Component {
     // When having no 'openMessages' or 'relationships' with 'openUserID',
     // displaying 'No messages'
     const skipRender = !openUserID ||
-      !(_.find(openMessages, openUserID)) ||
-      !(_.find(relationships, openUserID))
+      !(_.find(openMessages, { partnerId: openUserID })) ||
+      !(_.find(relationships, { partnerId: openUserID }))
 
     if (skipRender) {
       return (
@@ -26,15 +26,14 @@ class MessagesList extends React.Component {
       )
     }
 
-    const openMessagesWoHash = _.find(openMessages, openUserID)[openUserID]
     const lastMessage = openMessages[openMessages.length - 1]
-    const openRelationship = _.find(relationships, openUserID)[openUserID]
+    const openRelationship = _.find(relationships, { partnerId: openUserID })
     const timestamp_partner = (openRelationship.applicantId === openUserID)
       ? openRelationship.timestampApplicant
       : openRelationship.timestampRecipient
 
     // Rendering 'openMessages'
-    const messagesList = openMessagesWoHash.map((message, index) => {
+    const messagesList = openMessages.map((message, index) => {
       // Defining 'item_classes' for each message icon
       const itemClasses = classNames({
         'messages-list__item': true,

--- a/app/assets/javascripts/src/components/index/suggestionsList.js
+++ b/app/assets/javascripts/src/components/index/suggestionsList.js
@@ -24,7 +24,7 @@ class SuggestionsList extends React.Component {
     // ** When 'openUserID' is null, should not skip Rendering
     // ** Initialization of 'openUserID' needed afterwards
     const skipRenderAfterUpdate =
-      openUserID && !(_.find(suggestions, { 'id': openUserID }))
+      openUserID && !(_.find(suggestions, { id: openUserID }))
 
     if (skipRenderFirst || skipRenderAfterUpdate) {
       return (

--- a/app/assets/javascripts/src/components/index/userProf.js
+++ b/app/assets/javascripts/src/components/index/userProf.js
@@ -44,8 +44,8 @@ class UserProf extends React.Component {
     // When 'openUserID' does not match 'friends' or 'suggestions' list
     // (during rerender), displaying nothing
     const skipRenderAfterUpdate = (openUserTab === 'Friends')
-      ? !(_.find(friends, { 'id': openUserID }))
-      : !(_.find(suggestions, { 'id': openUserID }))
+      ? !(_.find(friends, { id: openUserID }))
+      : !(_.find(suggestions, { id: openUserID }))
 
     // When 'openUserID' is null (namely having no friends), displaying 'No...'
     if (skipRenderFirst || skipRenderAfterUpdate) {
@@ -59,8 +59,8 @@ class UserProf extends React.Component {
     // Defining 'userInfo' and 'linkText' which triggers a friendship change
     const linkText = (openUserTab === 'Friends') ? 'Unfriend?' : 'Be friends!'
     const userInfo = (openUserTab === 'Friends')
-      ? _.find(friends, { 'id': openUserID })
-      : _.find(suggestions, { 'id': openUserID })
+      ? _.find(friends, { id: openUserID })
+      : _.find(suggestions, { id: openUserID })
 
     // Defining 'item_classes' to distinguish 'openUserTab'
     // ** https://www.npmjs.com/package/classnames

--- a/app/assets/javascripts/src/components/index/userShortProf.js
+++ b/app/assets/javascripts/src/components/index/userShortProf.js
@@ -20,7 +20,7 @@ class UserShortProf extends React.Component {
 
     // When 'openUserID' does not match 'friends' list
     // (during rerender), displaying nothing
-    const skipRenderAfterUpdate = !(_.find(friends, { 'id': openUserID }))
+    const skipRenderAfterUpdate = !(_.find(friends, { id: openUserID }))
 
     if (skipRenderFirst || skipRenderAfterUpdate) {
       return <div className='user-short-prof__list user-short-prof__list__empty'></div>
@@ -29,8 +29,8 @@ class UserShortProf extends React.Component {
     // Defining 'userInfo' and 'contentName' to be displayed as an icon
     const contentName = (openContent === 'Profile') ? 'Messages' : 'Profile'
     const userInfo = (openUserTab === 'Friends')
-      ? _.find(friends, { 'id': openUserID })
-      : _.find(suggestions, { 'id': openUserID })
+      ? _.find(friends, { id: openUserID })
+      : _.find(suggestions, { id: openUserID })
     console.log(friends)
 
     return (

--- a/app/controllers/api_v2/relationships_controller.rb
+++ b/app/controllers/api_v2/relationships_controller.rb
@@ -19,7 +19,7 @@ class ApiV2::RelationshipsController < ApplicationController
       : user.friend_ids
 
     # Returning 'relationships'
-    relationships = user.relationships_mapped(with_ids: id_params)
+    relationships = user.relationships(partner_ids: id_params)
     render(json: relationships)
 
   end
@@ -80,12 +80,12 @@ class ApiV2::RelationshipsController < ApplicationController
       : @current_user
 
     # Destroying 'relationships' on scope
-    relationships_to_destroy = user.relationships(with_ids: [params[:partner_id]])
+    relationships_to_destroy = user.relationships(partner_ids: [params[:partner_id]])
     relationships_to_destroy.destroy_all
 
     # Destroying messages sent within this 'relationship'
     # ** Too complicated to validate within 'model'
-    messages_to_destroy = user.messages(with_ids: [params[:partner_id]])
+    messages_to_destroy = user.messages(partner_ids: [params[:partner_id]])
     messages_to_destroy.destroy_all
 
     render(json: '')


### PR DESCRIPTION
・user モデルでは、relationships の中にも { partner_id: x } の属性を持たせることに
・それにより、messagesList と friendsList でのユーザ検索が直感的に
（上記の変更に合わせて、suggestionsList, userShortProf, userProf のキーを string から symbol へ）